### PR TITLE
Fix url to avoid SSL error

### DIFF
--- a/acl/conference.py
+++ b/acl/conference.py
@@ -22,7 +22,7 @@ class Conference():
 
     @classmethod
     def _make_conference(cls, name, year):
-        url = "https://aclanthology.info/events/{}-{}".format(name, year)
+        url = "https://aclweb.org/anthology/events/{}-{}".format(name, year)
         return Conference(url)
 
     def retrieve(self, anthology="", interval=0.5,


### PR DESCRIPTION
```
Python 3.7.4 (default, Jul  9 2019, 18:13:23)
[Clang 10.0.1 (clang-1001.0.46.4)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from acl.conference import Conference
>>>
>>>
>>> Conference.ACL(2018).retrieve("P18-5").to_dataframe().to_csv("acl2018.csv", index=False)
Traceback (most recent call last):
  File "path_to_venvvenv/lib/python3.7/site-packages/urllib3/connectionpool.py", line 603, in urlopen
    chunked=chunked)
  File "path_to_venvvenv/lib/python3.7/site-packages/urllib3/connectionpool.py", line 344, in _make_request
    self._validate_conn(conn)
  File "path_to_venvvenv/lib/python3.7/site-packages/urllib3/connectionpool.py", line 843, in _validate_conn
    conn.connect()
  File "path_to_venvvenv/lib/python3.7/site-packages/urllib3/connection.py", line 390, in connect
    _match_hostname(cert, self.assert_hostname or server_hostname)
  File "path_to_venvvenv/lib/python3.7/site-packages/urllib3/connection.py", line 400, in _match_hostname
    match_hostname(cert, asserted_hostname)
  File "/usr/local/Cellar/python/3.7.4/Frameworks/Python.framework/Versions/3.7/lib/python3.7/ssl.py", line 334, in match_hostname
    % (hostname, ', '.join(map(repr, dnsnames))))
ssl.SSLCertVerificationError: ("hostname 'aclanthology.info' doesn't match either of 'aclweb.org', 'www.aclweb.org'",)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "path_to_venvvenv/lib/python3.7/site-packages/requests/adapters.py", line 449, in send
    timeout=timeout
  File "path_to_venvvenv/lib/python3.7/site-packages/urllib3/connectionpool.py", line 641, in urlopen
    _stacktrace=sys.exc_info()[2])
  File "path_to_venvvenv/lib/python3.7/site-packages/urllib3/util/retry.py", line 399, in increment
    raise MaxRetryError(_pool, url, error or ResponseError(cause))
urllib3.exceptions.MaxRetryError: HTTPSConnectionPool(host='aclanthology.info', port=443): Max retries exceeded with url: /events/acl-2018 (Caused by SSLError(SSLCertVerificationError("hostname 'aclanthology.info' doesn't match either of 'aclweb.org', 'www.aclweb.org'")))

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "path_to_venvvenv/lib/python3.7/site-packages/acl/conference.py", line 30, in retrieve
    r = requests.get(self.url)
  File "path_to_venvvenv/lib/python3.7/site-packages/requests/api.py", line 75, in get
    return request('get', url, params=params, **kwargs)
  File "path_to_venvvenv/lib/python3.7/site-packages/requests/api.py", line 60, in request
    return session.request(method=method, url=url, **kwargs)
  File "path_to_venvvenv/lib/python3.7/site-packages/requests/sessions.py", line 533, in request
    resp = self.send(prep, **send_kwargs)
  File "path_to_venvvenv/lib/python3.7/site-packages/requests/sessions.py", line 646, in send
    r = adapter.send(request, **kwargs)
  File "path_to_venvvenv/lib/python3.7/site-packages/requests/adapters.py", line 514, in send
    raise SSLError(e, request=request)
requests.exceptions.SSLError: HTTPSConnectionPool(host='aclanthology.info', port=443): Max retries exceeded with url: /events/acl-2018 (Caused by SSLError(SSLCertVerificationError("hostname 'aclanthology.info' doesn't match either of 'aclweb.org', 'www.aclweb.org'")))
```

- `aclanthology.info` is not redirected to `aclweb.org/anthology`
- `aclweb.org` enables HTTPS
- `url` is `https://aclanthology.info`

These conditions cause `SSLCertVerificationError`, which is solved in this PR.